### PR TITLE
extended the README with a standard structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,64 @@ All features will be planned in a modular way so that they can be used independe
 In order to have a real-world context, with many real dependencies, such as databases, authentication, request, persistent data storage and so on, we thought of programming a shopping app.
 
 Features: TBA <-- Breainstorming Session with SDN
+
+
+
+
+## Table of Contents
+
+- [](#)
+
+## Who We Are
+
+* List the project maintainers, core developers, and contact info
+* Link to Slack
+* website, online documentation 
+
+## Features
+
+* Project explanation
+
+## Prerequisites
+
+## Getting Started
+
+* Installation guidance
+
+## Project Structure
+
+| Name                               | Description                                                  |
+| ---------------------------------- | ------------------------------------------------------------ |
+|                                    |                                                              |
+
+## List of Packages
+
+| Package                         | Description                                                           |
+| ------------------------------- | --------------------------------------------------------------------- |
+|                                 |                                                                       |
+
+## Useful Tools and Resources
+
+## Recommended Design Resources
+
+## Recommended Libraries
+
+## Pro Tips
+
+## FAQ
+
+## How It Works (Mini Guides)
+
+## Deployment
+
+## Helpful Resources
+
+## Contributing
+
+## Contributors
+
+## Changelog
+
+## License  
+
+:top: <sub>[**back to top**](#table-of-contents)</sub>


### PR DESCRIPTION
I extended the README with a standard structure that lists topics like as Getting started, Project Structure, Tools and Resources, Deployment, Changelog etc.
I left the topics selfs empty, so we can fill them together with the group while working on the project.